### PR TITLE
Feature: quiet mode

### DIFF
--- a/ops.cr
+++ b/ops.cr
@@ -3,11 +3,14 @@ require "colorize"
 require "ops"
 
 def usage
-  STDERR.puts "Usage: ops [-f <filename>] <action>".colorize(:red)
+  STDERR.puts Builtins::Help.usage.colorize(:red)
   exit(1)
 end
 
 usage if ARGV.empty?
+
+# Enforce `--quiet` to act on a per-call basis.
+ENV.delete("OPS_QUIET_OUTPUT")
 
 while ARGV.first =~ /^-/
   opt = ARGV.first
@@ -18,6 +21,9 @@ while ARGV.first =~ /^-/
     usage if ARGV.empty?
 
     config_file = ARGV.shift
+  when "-q", "--quiet"
+    ARGV.shift
+    ENV["OPS_QUIET_OUTPUT"] = "true"
   else
     break
   end

--- a/ops.yml
+++ b/ops.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=./etc/ops.schema.yaml
 min_version: 2.0.0
 dependencies:
   brew:
@@ -20,7 +21,7 @@ dependencies:
     - shards install
     - bundle config --local path vendor/bundle
     - bundle
-    - ln -s `ops platform`/ops build/
+    - ln -sf `ops platform`/ops build/
     - true
     - echo "Initializing the cloud..."
 forwards:
@@ -77,3 +78,4 @@ actions:
 options:
   environment:
     INSTALL_DIR: "$HOME/bin/"
+    CRYSTAL_PATH: "`crystal env CRYSTAL_PATH`:./src"

--- a/spec/e2e/ops_q/e2e_spec.rb
+++ b/spec/e2e/ops_q/e2e_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.describe "forwards" do
+	let(:commands) do
+		[
+			"jenkins",
+			"-q jenkins",
+			"--quiet jenkins",
+		]
+	end
+
+	include_context "ops e2e"
+
+	it "succeeds" do
+		expect(exit_codes).to all eq(0)
+	end
+
+	it "outputs the command to stderr" do
+		expect(outputs[0]).to match(/echo "Hello, Leeeeeroy"/)
+	end
+
+	it "does not output the command to stderr when the `-q` flag is present" do
+		expect(outputs[1]).not_to match(/echo "Hello, Leeeeeroy"/)
+	end
+
+	it "does not output the command to stderr when the `--quiet` flag is present" do
+		expect(outputs[2]).not_to match(/echo "Hello, Leeeeeroy"/)
+	end
+end

--- a/spec/e2e/ops_q/ops.yml
+++ b/spec/e2e/ops_q/ops.yml
@@ -1,0 +1,2 @@
+actions:
+  jenkins: echo "Hello, Leeeeeroy"

--- a/spec/e2e/opt_f/e2e_spec.rb
+++ b/spec/e2e/opt_f/e2e_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "forwards" do
 		end
 
 		it "prints usage" do
-			expect(outputs[2]).to match(/Usage: ops/)
+			expect(outputs[2]).to match(/[\e\[\dm]+Usage:[\e\[\dm]+ ops/)
 		end
 	end
 end

--- a/src/builtins/help.cr
+++ b/src/builtins/help.cr
@@ -4,15 +4,20 @@ require "colorize"
 
 module Builtins
 	class Help < Builtin
-		@builtins : Array(String | Nil) | Nil
-
 		NAME_WIDTH = 30
 
 		def self.description
 			"displays available builtins, actions, and forwards"
 		end
 
+		def self.usage : String
+			"#{"Usage:".colorize(:white)} ops [-f <FILENAME>] [-q] [<FORWARD>] <ACTION> [...]"
+		end
+
 		def run : Bool
+			Output.out("")
+			Output.out("#{self.class.usage}\n\n")
+			
 			list("Builtins", builtins) if builtins.any?
 			list("Forwards", forwards) if forwards.any?
 			list("Actions", actions) if actions.any?
@@ -20,16 +25,26 @@ module Builtins
 			true
 		end
 
-		private def list(name, items)
-			Output.out("#{name}:")
-			Output.out("  #{items.join("\n  ")}")
+		private def list(name : String, items : Hash(String, String))
+			renders = items.map do |name, desc|
+				"  %-#{name_width}s  %s" % [name, description_string(desc)]
+			end
+
+			Output.out("#{name}:".colorize(:white).to_s)
+			Output.out("#{renders.join("\n")}")
 			Output.out("")
 		end
 
-		private def forwards
-			Forwards.new(@ops_yml).forwards.map do |name, dir|
-				"%-#{NAME_WIDTH}s %s" % [name.colorize(:yellow), dir.to_s]
-			end
+		private def name_width : Int32
+			@name_width ||= Math.max(name_longest.size, NAME_WIDTH).as(Int32)
+		end
+
+		private def name_longest : String
+			@name_longest ||= names.max_by { |name| name.size }.as(String)
+		end
+
+		private def names : Array(String)
+			@names ||= [*builtins.keys, *forwards.keys, *actions.keys].as(Array(String))
 		end
 
 		private def builtins
@@ -37,8 +52,14 @@ module Builtins
 				builtin_class = Builtins.class_for(builtin)
 				next unless builtin_class
 
-				"%-#{NAME_WIDTH}s %s" % [builtin_with_alias(builtin), builtin_class.description]
-			end
+				{ builtin_with_alias(builtin).to_s, builtin_class.description.to_s }
+			end.compact.to_h.as(Hash(String, String))
+		end
+
+		private def forwards
+			@forwards ||= Forwards.new(@ops_yml).forwards.to_h do |name, dir|
+				{ name.colorize(:red).to_s, dir.to_s }
+			end.as(Hash(String, String))
 		end
 
 		private def builtin_with_alias(name) : String
@@ -49,30 +70,31 @@ module Builtins
 		end
 
 		private def actions
-			return [] of String unless @ops_yml.actions
+			@actions ||= begin
+				return {} of String => String unless @ops_yml.actions
 
-			action_list = ActionList.new(@ops_yml.actions, [] of String)
-			action_list.names.map do |name|
-				action = action_list.get(name)
-				next if action.nil?
-
-				desc = action.description || action.command
-				name_and_aliases = if action.aliases.any?
-					"#{name.colorize(:yellow)} [#{action.aliases.join(",")}]"
-				else
-					name.colorize(:yellow)
-				end
-
-				"%-#{NAME_WIDTH}s %s" % [name_and_aliases, desc]
-			end
+				action_list = ActionList.new(@ops_yml.actions, [] of String)
+				action_list.names.map do |name|
+					action = action_list.get(name)
+					next if action.nil?
+	
+					desc = (action.description || action.command).to_s
+					name_and_aliases = name_string(name, action.aliases)
+	
+					{ name_and_aliases, desc }
+				end.compact.to_h
+			end.as(Hash(String, String))
 		end
 
-		private def alias_string_for(action_config : YAML::Any) : String
-			return "" if action_config.as_s?
+		private def name_string(name : String, aliases : Array(String)) : String
+			name = name.colorize(:cyan).to_s
+			return "#{name} [#{aliases.join(",")}]" if aliases.any?
 
-			return "[#{action_config["alias"]}]" if action_config["alias"]
+			name
+		end
 
-			""
+		private def description_string(content : String) : String
+			content.split("\n").join("\n  %-#{name_width}s  " % ["".colorize(:yellow)])
 		end
 	end
 end

--- a/src/dependencies/apt.cr
+++ b/src/dependencies/apt.cr
@@ -33,10 +33,11 @@ module Dependencies
 		end
 
 		private def sudo_string : String
-			return "" if ENV["USER"] == "root" || `whoami` == "root"
-      return "" if Options.get("apt.use_sudo") == false
-
+			return "" if ENV.keys.includes?("USER") && ENV["USER"] == "root"
+			return "" if `whoami` == "root"
+			return "" if Options.get("apt.use_sudo") == false
+			
 			"sudo "
-		end
+		  end
 	end
 end

--- a/src/output.cr
+++ b/src/output.cr
@@ -38,6 +38,8 @@ class Output
   end
 
   def self.notice(msg)
+    return if ENV.fetch("OPS_QUIET_OUTPUT", "false") == "true"
+
     warn(msg)
   end
 
@@ -62,7 +64,7 @@ class Output
   end
 
   def self.debug(msg)
-    return unless ENV.keys.includes?("OPS_DEBUG_OUTPUT") && ENV["OPS_DEBUG_OUTPUT"] == "true"
+    return unless ENV.fetch("OPS_DEBUG_OUTPUT", "false") == "true"
 
     @@err.puts(msg.colorize(:blue))
   end


### PR DESCRIPTION
## Fixes
* Bug where `apt` fails if `$USER` is unset.
## Changes
### Quiet Mode
* Introduces `ops --quiet|-q` flag.
* Introduces `$OPS_QUIET_OUTPUT` _internal_ env-var.
### Help Doc Alignment
* Reworks `help.cr` a fair bit.
* Moves usage text into `Builtins::Help`.
* Reworks `opt_f/e2e_spec.rb` to account for changes.
### Misc
* Configures `$CRYSTAL_PATH`, implicitly, in `./ops.yml`.
## Tests
* macOS 13.4 (22F66) [arm64]
* Ubuntu 22.04.2 LTS [amd64]