### PR TITLE
Feature: param expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 > Note: Darwin x86_64 binary is 2.1.2
 
+## 2.3.0 (gem 2.3.0.rc1)
+
+- don't swallow quotes when executing actions in a shell (LeShaunJ)
+- process shebangs in action bodies to allow actions to be written for any interpreter (LeShaunJ)
+- switch to `dash` for internal shell by default (LeShaunJ)
+- support positional arg interpolation (LeShaunJ)
+
 ## 2.2.0 (gem 2.2.0.rc1)
 
 - add `--quiet`/`-q` command-line option to silence the "Running ... in environment ..." output when `ops` runs an action (from @LeShaunJ)

--- a/rubygem/ops_team.gemspec
+++ b/rubygem/ops_team.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
 	s.name = 'ops_team'
-	s.version = '2.2.0.rc1'
+	s.version = '2.3.0.rc1'
 	s.authors = [
 		'nickthecook@gmail.com'
 	]

--- a/spec/e2e/e2e_spec_helper.rb
+++ b/spec/e2e/e2e_spec_helper.rb
@@ -21,7 +21,7 @@ shared_context "ops e2e" do
 		untracked_files.each { |file| `rm -f #{file}` }
 	end
 
-	def ops(cmd, output_file = "ops.out")
+	def ops(cmd, output_file = "ops.out", **opts)
 		path = "../bin/ops"
 		5.times do
 			break path if File.executable?(path)
@@ -29,16 +29,21 @@ shared_context "ops e2e" do
 			path = "../#{path}"
 		end
 
-		output, status = Open3.capture2e(ops_env_vars, "#{path} #{cmd}")
+		output, status = Open3.capture2e(ops_env_vars, "#{path} #{cmd}", **opts)
 
 		File.write(output_file, output)
 
 		[output, output_file, status.exitstatus]
 	end
 
+	let!(:ops_args) do
+		commands.map do |cmd|
+			cmd.is_a?(Array) ? cmd : [cmd, {}]
+		end
+	end
 	let!(:results) do
-		commands.map do |command|
-			ops(command)
+		ops_args.map do |command, opts|
+			ops(command, **opts)
 		end
 	end
 	let(:exit_codes) { results.map { |result| result[EXIT_CODE_IDX] } }

--- a/spec/e2e/param_expansion/e2e_spec.rb
+++ b/spec/e2e/param_expansion/e2e_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+RSpec.describe "forwards" do
+	let(:commands) do
+		[
+			"expansion one two three",
+			"expansion one two \"three four five\"",
+			"numargs '1 2' 3",
+			["shebang_bash one two three \"four five\"", { stdin_data: "goodbye, world\n" }],
+			["shebang_python world earth", { stdin_data: "goodbye, world" }],
+			["shebang_ruby world earth", { stdin_data: "goodbye, world" }],
+		]
+	end
+
+	include_context "ops e2e"
+
+	it "succeeds" do
+		expect(exit_codes).to all eq(0)
+	end
+
+	it "performs param expansion when enabled in config" do
+		expect(outputs[0]).to match(/\nFirst: one\nSecond: two\nThird: three\n$/)
+	end
+
+	it "preserves shell-quoting when enabled in config" do
+		expect(outputs[1]).to match(/\nFirst: one\nSecond: two\nThird: three four five\n$/)
+	end
+
+	it "preserves arg count when enabled in config" do
+		expect(outputs[2]).to match(/2\n$/)
+	end
+
+	it "interprets bash shebang and prints stdin when enabled in config" do
+		expect(outputs[3]).to match(/\nFirst: one\nSecond: two\nOther: three\nOther: four five\ngoodbye, world\n$/)
+	end
+
+	it "interprets python shebang and prints stdin when enabled in config" do
+		expect(outputs[4]).to match(/\nhello, \+world>> earth\+\ngoodbye, world\n$/)
+	end
+
+	it "interprets ruby shebang and prints stdin when enabled in config" do
+		expect(outputs[5]).to match(/\nhello, \+world>> earth\+\ngoodbye, world\n$/)
+	end
+end

--- a/spec/e2e/param_expansion/e2e_spec.rb
+++ b/spec/e2e/param_expansion/e2e_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe "forwards" do
 			["shebang_bash one two three \"four five\"", { stdin_data: "goodbye, world\n" }],
 			["shebang_python world earth", { stdin_data: "goodbye, world" }],
 			["shebang_ruby world earth", { stdin_data: "goodbye, world" }],
+			"empty",
+			"shebang_only",
 		]
 	end
 
@@ -38,7 +40,19 @@ RSpec.describe "forwards" do
 		expect(outputs[4]).to match(/\nhello, \+world>> earth\+\ngoodbye, world\n$/)
 	end
 
+	it "recommends using `-S` with multi-parameter `#!/usr/bin/env` shebangs when enabled in config" do
+		expect(outputs[4]).to match(/`-S ...` is recommended\b/)
+	end
+
 	it "interprets ruby shebang and prints stdin when enabled in config" do
 		expect(outputs[5]).to match(/\nhello, \+world>> earth\+\ngoodbye, world\n$/)
+	end
+
+	it "interprets empty script as `sh` and exits 0 when enabled in config" do
+		expect(exit_codes[6]).to eq(0)
+	end
+
+	it "interprets lone shebang and exits 0 when enabled in config" do
+		expect(exit_codes[7]).to eq(0)
 	end
 end

--- a/spec/e2e/param_expansion/ops.yml
+++ b/spec/e2e/param_expansion/ops.yml
@@ -1,0 +1,38 @@
+hooks:
+  before:
+    - echo app before hook
+actions:
+  expansion:
+    command: |-
+      echo "First: ${1}";
+      echo "Second: ${2}";
+      echo "Third: ${3}";
+    param_expansion: true
+  numargs:
+    command: echo "$#"
+    param_expansion: true
+  shebang_bash:
+    command: |-
+      #!/usr/bin/env bash
+      echo "First: ${1}";
+      echo "Second: ${2}";
+      printf 'Other: %s\n' "${@:3}";
+      [ -t 0 ] || cat -;
+    param_expansion: true
+  shebang_python:
+    command: |-
+      #!/usr/bin/env python3
+      import sys, select
+      print(f"hello, +{'>> '.join(sys.argv[1:])}+")
+      if select.select([sys.stdin, ], [], [], 0.0)[0]:
+        print(sys.stdin.read().strip())
+    param_expansion: true
+  shebang_ruby:
+    command: |-
+      #!/usr/bin/env ruby
+      require 'fcntl'
+      puts "hello, +#{ARGV.join('>> ')}+"
+      if STDIN.fcntl(Fcntl::F_GETFL, 0) == 0
+        puts STDIN.read
+      end
+    param_expansion: true

--- a/spec/e2e/param_expansion/ops.yml
+++ b/spec/e2e/param_expansion/ops.yml
@@ -21,7 +21,7 @@ actions:
     param_expansion: true
   shebang_python:
     command: |-
-      #!/usr/bin/env python3
+      #!/usr/bin/env python3 -W ignore
       import sys, select
       print(f"hello, +{'>> '.join(sys.argv[1:])}+")
       if select.select([sys.stdin, ], [], [], 0.0)[0]:
@@ -35,4 +35,11 @@ actions:
       if STDIN.fcntl(Fcntl::F_GETFL, 0) == 0
         puts STDIN.read
       end
+    param_expansion: true
+  empty:
+    command: ""
+    param_expansion: true
+  shebang_only:
+    command: |-
+      #!/usr/bin/env python3
     param_expansion: true

--- a/spec/e2e/shell_expansion/e2e_spec.rb
+++ b/spec/e2e/shell_expansion/e2e_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "forwards" do
 	end
 
 	it "expands args by default" do
-		expect(outputs[2]).to match(/3\n$/)
+		expect(outputs[2]).to match(/2\n$/)
 	end
 
 	it "preserves arg count when disabled in config" do
@@ -35,7 +35,7 @@ RSpec.describe "forwards" do
 	end
 
 	it "concatenates args in config with args on command-line" do
-		expect(outputs[4]).to match(/4\n$/)
+		expect(outputs[4]).to match(/3\n$/)
 	end
 
 	it "concatenates args and preserves count" do

--- a/src/action.cr
+++ b/src/action.cr
@@ -174,6 +174,6 @@ class Action
   end
 
   private def perform_param_expansion? : Bool
-    @config.fetch("param_expansion", YAML.parse("false")).as_bool.as(Bool)
+    @config.fetch("param_expansion", YAML.parse("false")).as_bool
   end
 end

--- a/src/interpreter.cr
+++ b/src/interpreter.cr
@@ -1,0 +1,95 @@
+
+struct Interpreter
+  @@shell : String | Nil
+
+  protected def self.shell : String
+    {% if flag?(:darwin) %}
+      @@shell ||= begin
+        Process.find_executable(ENV.fetch("RUBYSHELL", "dash")).as(String)
+      rescue TypeCastError
+        Process.find_executable(ENV.fetch("RUBYSHELL", "sh")).as(String)
+      end
+    {% else %}
+      @@shell ||= Process.find_executable(ENV.fetch("RUBYSHELL", "sh")).as(String)
+    {% end %}
+  end
+
+  # Ripped from Crystal::System::FileDescriptor#pipe, except we don't want `reader` to close-on-exec.
+  protected def self.pipe(command : String) : {IO::FileDescriptor, IO::FileDescriptor}
+    pipe_fds = uninitialized StaticArray(LibC::Int, 2)
+    raise IO::Error.from_errno("Could not create pipe") if LibC.pipe(pipe_fds) != 0
+
+    reader = IO::FileDescriptor.new(pipe_fds[0], false)
+    writer = IO::FileDescriptor.new(pipe_fds[1], false)
+    writer.close_on_exec = true
+    writer.sync = true
+    writer << command
+
+    {reader, writer}
+  end
+
+  # Ditto, except we only yield the path.
+  protected def self.pipe(command : String, &)
+    reader, writer = pipe(command)
+
+    begin
+      yield "/dev/fd/#{reader.fd}"
+    ensure
+      writer.flush
+      reader.close
+      writer.close
+    end
+  end
+
+  #######################################################################################
+
+  getter :name, :options, :script
+
+  @name : String = shell
+  @options : Array(String) = [] of String
+  @script : String = ""
+
+  def initialize(content : String)
+    match = /(\A#!.+\n|)([\S\s]*)\Z/.match(content).as(Regex::MatchData)
+    shebang = Process.parse_arguments(match[1])
+    shebang << self.class.shell unless shebang.any?
+
+    self.name = shebang
+    @script = match[2]
+  end
+
+  def exec(args : Array(String))
+    exit 0 if noop?
+
+    self.class.pipe(script) do |path|
+      Process.exec(name, [*options, path, *args])
+    end
+  end
+
+  def noop?
+    script.empty?
+  end
+
+  def to_pretty(args : String = "")
+    env_s = needs_env_split? ? "-S" : ""
+    opts = Process.quote(options)
+    shebang = [name, env_s, opts].reject(&.empty?).join(" ")
+    content = "<(\ncat <<'EOF'\n#{script.strip}\nEOF\n)"
+
+    [shebang, content, args].reject(&.empty?).join(" ")
+  end
+
+  private def name=(shebang : Array(String))
+    @name = Process.find_executable(shebang[0].gsub(/^#!/, "")).as(String)
+
+    @options = begin
+      return [] of String unless shebang.size > 1
+
+      shebang[1..]
+    end.as(Array(String))
+  end
+
+  private def needs_env_split?
+    File.basename(name) == "env" && options.size > 1
+  end
+end

--- a/src/interpreter.cr
+++ b/src/interpreter.cr
@@ -80,7 +80,7 @@ struct Interpreter
     [interpreter_call, standard_input, args].reject(&.empty?).join(" ")
   end
 
-  private def parse(shebang : Array(String)) : Void
+  private def parse(shebang : Array(String)) : Nil
     @name = Process.find_executable(shebang[0].gsub(/^#!/, "")).as(String)
 
     @options = begin

--- a/src/interpreter.cr
+++ b/src/interpreter.cr
@@ -51,8 +51,8 @@ struct Interpreter
   @options : Array(String) = [] of String
   @code : String = ""
 
-  def initialize(content : String)
-    match = /(\A#!.+\n|)([\S\s]*)\Z/.match(content).as(Regex::MatchData)
+  def initialize(script : String)
+    match = /(\A#!.+\n|)([\S\s]*)\Z/.match(script).as(Regex::MatchData)
     shebang = Process.parse_arguments(match[1])
     shebang << self.class.shell unless shebang.any?
 

--- a/src/runner.cr
+++ b/src/runner.cr
@@ -94,7 +94,7 @@ class Runner
       return true
     end
 
-    Output.notice("Running '#{@action.to_s}' in environment '#{ENV["environment"]}'...")
+    Output.notice("Running #{@action.not_nil!.to_log} in environment '#{ENV["environment"]}'...")
     action.not_nil!.run
   end
 

--- a/src/version.cr
+++ b/src/version.cr
@@ -2,11 +2,11 @@ require "semantic_version"
 
 class Version
   def self.name_and_version
-    "crops-#{version}"
+    "crops-#{version}.rc1"
   end
 
   def self.version : String
-    "2.2.0"
+    "2.3.0"
   end
 
   def self.min_version_met?(min_version) : Bool


### PR DESCRIPTION
## Changes
### Param Expansion
* Introduces `actions.*.param_expansion`.
* Introduces `Interpreter` class.
* Commands can supply a shebang for inline language suuport.
* Uses `dash` as default shell for `darwin`:
  * `/bin/sh` on `darwin` is actually `/bin/bash`
  * This results in a schism between `darwin` & `linux`.
  * `darwin` actions would then benfit from `bash` features.
  * Those same actions may fail on `linux`.
* Includes end-to-end tests.
### No Shell Expansion
* Uses `Process.quote` instead of stripping quote.
* Reworks `shell_expansion/e2e_spec.rb` to account for this.
### Misc
* Supports `stdin` in `e2e_spec_helper.rb`.
## Tests
* macOS 13.4 (22F66) [arm64]
* Ubuntu 22.04.2 LTS [amd64]